### PR TITLE
Compress rotated files in background.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 BSD 2-Clause License
 
 Copyright (c) 2017, moshee
+Copyright (c) 2017, Josh Rickmar <jrick@devio.us>
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/rotator/rotator.go
+++ b/rotator/rotator.go
@@ -127,7 +127,10 @@ func (r *Rotator) rotate() error {
 
 	r.wg.Add(1)
 	go func() {
-		compress(rotname)
+		err := compress(rotname)
+		if err == nil {
+			os.Remove(rotname)
+		}
 		r.wg.Done()
 	}()
 
@@ -139,13 +142,7 @@ func compress(name string) (err error) {
 	if err != nil {
 		return err
 	}
-
-	defer func() {
-		f.Close()
-		if err == nil {
-			os.Remove(name)
-		}
-	}()
+	defer f.Close()
 
 	arc, err := os.OpenFile(name+".gz", os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0644)
 	if err != nil {


### PR DESCRIPTION
This prevents the Run loop from blocking on compression and in most
cases removes the need for applications to add a buffer between the
reader and writer to avoid slowdown during rotation.